### PR TITLE
メンバーCRUD機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ gem 'bootstrap'
 gem 'jquery-rails'
 gem 'rails-i18n'
 gem 'bcrypt', '~> 3.1.7'
+gem 'pry-rails'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    coderay (1.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -115,6 +116,11 @@ GEM
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     popper_js (1.16.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.5)
     puma (3.12.6)
     rack (2.2.3)
@@ -223,6 +229,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  pry-rails
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.2)
   rails-i18n

--- a/app/assets/javascripts/members.coffee
+++ b/app/assets/javascripts/members.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/members.scss
+++ b/app/assets/stylesheets/members.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the members controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,0 +1,46 @@
+class MembersController < ApplicationController
+    before_action :login_required, only: [ :new, :create, :edit, :update, :destroy]
+
+    def index
+        @members = Member.all.recent
+    end
+
+    def show
+        @member = Member.find(params[:id])
+    end
+
+    def new
+        @member = Member.new
+    end
+
+    def create
+        @member = Member.new(member_params)
+        if @member.save
+            redirect_to @member, notice: "#{@member.name}を登録しました。"
+        else
+            render :new
+        end
+    end
+
+    def edit
+        @member = Member.find(params[:id])
+    end
+
+    def update
+        member = Member.find(params[:id])
+        member.update!(member_params)
+        redirect_to members_path, notice: "#{member.name}を編集しました。"
+    end
+
+    def destroy
+        member = Member.find(params[:id])
+        member.destroy
+        redirect_to members_path, notice: "#{member.name}を削除しました。"
+    end
+
+    private
+
+    def member_params
+        params.require(:member).permit(:name, :description)
+    end
+end

--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -1,0 +1,2 @@
+module MembersHelper
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,0 +1,4 @@
+class Member < ApplicationRecord
+    validates :name, presence: true, length: { maximum: 30}
+    scope :recent, -> { order(created_at: :desc).limit(5) }
+end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -29,5 +29,5 @@
         <%= f.label :password_confirmation, 'パスワード(確認)' %>
         <%= f.password_field :password_confirmation, class: 'form-control' %>
     </div>
-    <%= f.submit '登録する', class: 'btn btn-primary' %>
+    <%= f.submit '登録する', class: 'btn btn-outline-primary' %>
 <% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,4 +1,4 @@
 <h1><%= @user.name %>を編集する</h1>
-<%= link_to '従業員一覧', admin_users_path, class: 'btn btn-success' %>
+<%= link_to '管理者一覧にもどる', admin_users_path, class: 'btn btn-success' %>
 <%= link_to 'TOPにもどる', root_path, class: 'btn btn-primary' %>
 <%= render partial: 'form', locals: { user: @user } %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,6 +1,6 @@
-<h1>従業員一覧</h1>
+<h1>管理者一覧</h1>
 
-<%= link_to '新規登録', new_admin_user_path, class: 'btn btn-success' %>
+<%= link_to '新規登録', new_admin_user_path, class: 'btn btn-info' %>
 <%= link_to 'TOPにもどる', root_path, class: 'btn btn-primary' %>
 
 <div class='row'>
@@ -11,7 +11,7 @@
                 <%= image_tag 'no_image.png', class: 'card-img-top', size: '300x300' %>
                 <div class="card-body webkit-center">
                     <h4><%= user.name %></h4>
-                    <%= link_to '編集', edit_admin_user_path(user), class: 'btn btn-primary' %>
+                    <%= link_to '編集', edit_admin_user_path(user), class: 'btn btn-outline-success' %>
                     <%= link_to '削除', [:admin, user], method: :delete, data: { confirm: "「#{user.name}」を削除します。よろしいですか？"}, class: 'btn btn-danger' %>
                 </div>
             </div>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,4 +1,4 @@
-<h1>従業員登録</h1>
-<%= link_to '従業員一覧', admin_users_path, class: 'btn btn-success' %>
+<h1>管理者登録</h1>
 <%= link_to 'TOPにもどる', root_path, class: 'btn btn-primary' %>
+<%= link_to '管理者一覧にもどる', admin_users_path, class: 'btn btn-success' %>
 <%= render partial: 'form', locals: { user: @user } %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,5 +1,5 @@
 <h1><%= @user.name %></h1>
-<%= link_to '従業員一覧', admin_users_path, class: 'btn btn-success' %>
-<%= link_to 'TOPに戻る', root_path, class: 'btn btn-primary' %>
-<%= link_to '編集', edit_admin_user_path(id: @user.id), class: 'btn btn-primary' %>
+<%= link_to '管理者一覧にもどる', admin_users_path, class: 'btn btn-success' %>
+<%= link_to 'TOPにもどる', root_path, class: 'btn btn-primary' %>
+<%= link_to '編集', edit_admin_user_path(id: @user.id), class: 'btn btn-outline-success' %>
 <%= link_to '削除', [:admin, @user], method: :delete, data: { confirm: "「#{@user.name}」を削除します。よろしいですか？"}, class: 'btn btn-danger' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,8 @@
     <ul class="navbar-nav ml-auto">
       <% if current_user.present? %>
         <li class="nav-item"><%= link_to 'トップ',root_path, class: 'nav-link' %></li>
-        <li class="nav-item"><%= link_to 'ユーザー一覧',admin_users_path, class: 'nav-link' %></li>
+        <li class="nav-item"><%= link_to '管理者一覧',admin_users_path, class: 'nav-link' %></li>
+        <li class="nav-item"><%= link_to 'メンバー一覧',members_path, class: 'nav-link' %></li>
         <li class="nav-item"><%= link_to 'ログアウト',logout_path, method: :delete, class: 'nav-link' %></li>
       <% else %>
         <li class="nav-item"><%= link_to 'ログイン',login_path, class: 'nav-link' %></li>

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -1,0 +1,21 @@
+<% if member.errors.present? %>
+  <ul id="error_explanation">
+    <% member.errors.full_messages.each do |message| %>
+      <li><%= message %></li>
+    <% end %>
+  </ul>
+<% end %>
+
+
+
+<%= form_with model: member, local: true do |f| %>
+  <div class="form-group">
+    <%= f.label :name %>
+    <%= f.text_field :name, class: 'form-control', id: 'member_name' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :description %>
+    <%= f.text_area :description, class: 'form-control', id: 'member_description' %>
+  </div>
+  <%= f.submit nil, class: 'btn btn-outline-primary' %>
+<% end %>

--- a/app/views/members/destroy.html.erb
+++ b/app/views/members/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>Products#destroy</h1>
+<p>Find me in app/views/members/destroy.html.erb</p>

--- a/app/views/members/destroy.html.erb
+++ b/app/views/members/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>Products#destroy</h1>
-<p>Find me in app/views/members/destroy.html.erb</p>

--- a/app/views/members/edit.html.erb
+++ b/app/views/members/edit.html.erb
@@ -1,0 +1,4 @@
+<%= link_to 'TOPにもどる', members_path, class: 'btn btn-primary' %>
+<%= link_to 'メンバー一覧にもどる', members_path, class: 'btn btn-warning' %>
+<h1><%= @member.name %>を編集する</h1>
+<%= render partial: 'form', locals: { member: @member } %>

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -1,0 +1,20 @@
+<h1>メンバー一覧</h1>
+<%= link_to '新規登録', new_member_path, class: 'btn btn-info' %>
+<%= link_to 'TOPにもどる', root_path, class: 'btn btn-primary' %>
+<div class='row'>
+    <% @members.each do |member| %>
+        <%= link_to member_path(id: member.id) do %>
+        <div class='col-md-4 mt-5'>
+            <div class='card' style='width: 18rem;'>
+                <%= image_tag 'no_image.png', class: 'card-img-top', size: '300x300' %>
+                <div class="card-body webkit-center">
+                    <h4><%= member.name %></h4>
+                    <p class="card-text"><%= member.description %></p>
+                    <%= link_to '編集', edit_member_path(id: member.id), class: 'btn btn-outline-success' %>
+                    <%= link_to '削除', member, method: :delete, data: { confirm: "「#{member.name}」を削除します。よろしいですか？"}, class: 'btn btn-danger' %>
+                </div>
+            </div>
+        </div>
+        <% end %>
+    <% end %>
+</div>

--- a/app/views/members/new.html.erb
+++ b/app/views/members/new.html.erb
@@ -1,0 +1,4 @@
+<h1>メンバーの登録</h1>
+<%= link_to 'TOPにもどる', root_path, class: 'btn btn-primary' %>
+<%= link_to 'メンバー一覧にもどる', members_path, class: 'btn btn-warning' %>
+<%= render partial: 'form', locals: { member: @member } %>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -1,0 +1,6 @@
+<%= link_to 'TOPにもどる', root_path, class: 'btn btn-primary' %>
+<%= link_to 'メンバー一覧にもどる', members_path, class: 'btn btn-warning' %>
+<h1><%= @member.name %></h1>
+<p><%= @member.description %></p>
+<%= link_to '編集', edit_member_path(id: @member.id), class: 'btn btn-outline-success' %>
+<%= link_to '削除', @member, method: :delete, data: { confirm: "「#{@member.name}」を削除します。よろしいですか？"}, class: 'btn btn-danger' %>

--- a/app/views/products/_form.html.erb
+++ b/app/views/products/_form.html.erb
@@ -17,5 +17,5 @@
     <%= f.label :description %>
     <%= f.text_area :description, class: 'form-control', id: 'product_description' %>
   </div>
-  <%= f.submit nil, class: 'btn btn-primary' %>
+  <%= f.submit nil, class: 'btn btn-outline-primary' %>
 <% end %>

--- a/app/views/products/destroy.html.erb
+++ b/app/views/products/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>Products#destroy</h1>
-<p>Find me in app/views/products/destroy.html.erb</p>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -1,3 +1,3 @@
-<%= link_to 'TOPに戻る', products_path, class: 'btn btn-primary' %>
+<%= link_to 'TOPにもどる', products_path, class: 'btn btn-primary' %>
 <h1><%= @product.name %>を編集する</h1>
 <%= render partial: 'form', locals: { product: @product } %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -1,6 +1,7 @@
 <h1>事業一覧</h1>
-<%= link_to '新規登録', new_product_path, class: 'btn btn-primary' %>
-<%= link_to '従業員一覧', admin_users_path, class: 'btn btn-success' %>
+<%= link_to '新規登録', new_product_path, class: 'btn btn-info' %>
+<%= link_to '管理者一覧', admin_users_path, class: 'btn btn-success' %>
+<%= link_to 'メンバー一覧', members_path, class: 'btn btn-warning' %>
 
 <div class='row'>
     <% @products.each do |product| %>
@@ -11,7 +12,7 @@
                 <div class="card-body webkit-center">
                     <h4><%= product.name %></h4>
                     <p class="card-text"><%= product.description %></p>
-                    <%= link_to '編集', edit_product_path(id: product.id), class: 'btn btn-primary' %>
+                    <%= link_to '編集', edit_product_path(id: product.id), class: 'btn btn-outline-success' %>
                     <%= link_to '削除', product, method: :delete, data: { confirm: "「#{product.name}」を削除します。よろしいですか？"}, class: 'btn btn-danger' %>
                 </div>
             </div>

--- a/app/views/products/new.html.erb
+++ b/app/views/products/new.html.erb
@@ -1,4 +1,4 @@
 <h1>今までおこなった事業の登録</h1>
-<%= link_to 'TOPに戻る', root_path, class: 'btn btn-primary' %>
+<%= link_to 'TOPもどる', root_path, class: 'btn btn-primary' %>
 
 <%= render partial: 'form', locals: { product: @product } %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,5 +1,5 @@
-<%= link_to 'TOPに戻る', root_path, class: 'btn btn-primary' %>
+<%= link_to 'TOPもどる', root_path, class: 'btn btn-primary' %>
 <h1><%= @product.name %></h1>
 <p><%= @product.description %></p>
-<%= link_to '編集', edit_product_path(id: @product.id), class: 'btn btn-primary' %>
+<%= link_to '編集', edit_product_path(id: @product.id), class: 'btn btn-outline-success' %>
 <%= link_to '削除', @product, method: :delete, data: { confirm: "「#{@product.name}」を削除します。よろしいですか？"}, class: 'btn btn-danger' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,6 @@ Rails.application.routes.draw do
     resources :users
   end
   resources :products
+  resources :members
   root to: 'products#index'
 end

--- a/db/migrate/20200924193821_create_members.rb
+++ b/db/migrate/20200924193821_create_members.rb
@@ -1,0 +1,9 @@
+class CreateMembers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :members do |t|
+      t.string :name
+      t.text :descriprion
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200924200741_rename_descriprion_column_to_members.rb
+++ b/db/migrate/20200924200741_rename_descriprion_column_to_members.rb
@@ -1,0 +1,5 @@
+class RenameDescriprionColumnToMembers < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :members, :descriprion, :description
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_10_072916) do
+ActiveRecord::Schema.define(version: 2020_09_24_200741) do
+
+  create_table "members", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "products", force: :cascade do |t|
     t.string "name", limit: 31, null: false


### PR DESCRIPTION
対応イシュー : #7 
この実現するにあたって以下を追加及び変更した

## コントローラの追加
membersコントローラを追加し以下のアクションを設けた
 - new
 - destroy
 - create
 - index
 - show
 - edit
 - update

## ビューの追加及び変更
memberにおける以下ビュー追加
 - new
 - index
 - show
 - edit


## ルーティングの追加
memberに`resource`でCRUDによるルーティング

## その他

### productとuserのボタン及び名称変更

### カラム名のリネーム
productモデルを参考に`rails db:migrate`すると`description`カラムの名称が`descrip"r"ion`になってしまった。
以下の記事を参考にリネームした。
[unknown attribute '○○○○' for ○○○. →カラムのリネーム](https://qiita.com/Ayaka_ramens/items/f0c68b08fcf6145c2b17)

### SQLite3がブロック
リネーム後、`rails db:migrate`しようとしたら SQLite3がブロックされて中断される。
以下の記事を参考に復旧した。
[Ruby:SQLite3 :: BusyException:データベースがロックされています](https://www.366service.com/jp/qa/ebecdcec781305b2e0489f29d71660b1)